### PR TITLE
fixed parameters for Vagrant 0.9 and added a box that's publicly available

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,8 @@ Vagrant::Config.run do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "squeeze64"
+  config.vm.box = "ubuntu11.04_puppet"
+  config.vm.box_url = "https://github.com/downloads/divio/vagrant-boxes/vagrant-ubuntu-11.04-server-amd64-v1.box"
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
@@ -19,9 +20,9 @@ Vagrant::Config.run do |config|
 
   # Forward a port from the guest to the host, which allows for outside
   # computers to access the VM, whereas host only networking does not.
-  config.vm.forward_port "http", 80, 8080
-  config.vm.forward_port "carbon", 2003, 2003
-  config.vm.forward_port "statsd", 8125, 8125, { :protocol => 'udp' }
+  config.vm.forward_port 80, 8080
+  config.vm.forward_port 2003, 2003
+  config.vm.forward_port 8125, 8125, { :protocol => 'udp' }
 
   # Share an additional folder to the guest VM. The first argument is
   # an identifier, the second is the path on the guest to mount the


### PR DESCRIPTION
I had some problems to get the VM working with Vagrant 0.9, had to fix the Vagrantfile and I put a URL to a box from vagrantbox.es in it. Works now with the current Version of Vagrant and out of the box.
Would be great if you could pull this in :-) And thanks for this, it makes playing around with graphite and statsd a lot easier!
