### PR TITLE
Correct the puppet file references and add default account to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ vagrant up
 open http://localhost:8080/
 ```
 
+The default account is admin/admin
+
 ## Contributors
 
 Created by jimdo https://github.com/Jimdo

--- a/puppet/modules/carbon/manifests/init.pp
+++ b/puppet/modules/carbon/manifests/init.pp
@@ -13,19 +13,19 @@ class carbon {
   }
 
  file { "/etc/init.d/carbon" :
-   source => "/tmp/vagrant-puppet/modules-0/carbon/files/carbon",
+   source => "puppet:///modules/carbon/carbon",
    ensure => present,
  }
 
  file { "/opt/graphite/conf/carbon.conf" :
-   source => "/tmp/vagrant-puppet/modules-0/carbon/files/carbon.conf",
+   source => "puppet:///modules/carbon/carbon.conf",
    ensure => present,
    notify => Service[carbon],
    subscribe => Exec[install-carbon],
  }
 
  file { "/opt/graphite/conf/storage-schemas.conf" :
-   source => "/tmp/vagrant-puppet/modules-0/carbon/files/storage-schemas.conf",
+   source => "puppet:///modules/carbon/storage-schemas.conf",
    ensure => present,
    notify => Service[carbon],
    subscribe => Exec[install-carbon],

--- a/puppet/modules/graphite/manifests/init.pp
+++ b/puppet/modules/graphite/manifests/init.pp
@@ -80,7 +80,7 @@ class graphite {
   }
 
   file { "/opt/graphite/webapp/graphite/local_settings.py" :
-    source => "/tmp/vagrant-puppet/modules-0/graphite/files/local_settings.py",
+    source => "puppet:///modules/graphite/local_settings.py",
     ensure => present,
     require => File["/opt/graphite/storage"]
  }


### PR DESCRIPTION
The puppet mount point can be different each time so the puppet config needs to reference via the puppet path. This should always work.

Also added the default user to the README so people don't have to dig into the graphite puppet module.
